### PR TITLE
Refactoring Assessment model,removing the rubricsJSON column from the Assessment Model database. There's no need to store the rubricsJSON inside the AssessmentModel since we can access it through Rubrics Model

### DIFF
--- a/controllers/assessments-controller.js
+++ b/controllers/assessments-controller.js
@@ -55,28 +55,6 @@ module.exports = (app) => {
           error: err
         })
       })
-
-    // db.Assessment.findOrCreate({ where: params, defaults: req.body })
-    // .all().then((assessment, created) => {
-    //   callback && callback(null, assessment, created);
-    // },
-    // (error) => {
-    //   callback && callback(error);
-    // });
-    //
-    // const callback = (error, result, created) => {
-    //   if (error) {
-    //     console.log("Error in Assessment Create Route:", error);
-    //     res.send(400, { message: "Error!", error })
-    //   } else {
-    //     console.log("New Assessment Created? ", created)
-    //     res.send({
-    //       message: (created ? "Assessment was successfully created" : "Assessment was successfully found"),
-    //       created,
-    //       result
-    //     })
-    //   }
-    // };
   });
 
 

--- a/controllers/assessments-controller.js
+++ b/controllers/assessments-controller.js
@@ -6,53 +6,55 @@ module.exports = (app) => {
   // Show or Create a Assessment
   app.get('/users/:userId/rubrics/:rubricId/assessments/', (req, res) => {
     const params = { userId: req.params.userId, rubricId: req.params.rubricId }
-    db.Rubric.findOne({
-      where: {
-        id: req.params.rubricId
-      },
-      include: [{
-        model: db.Competency,
-        include: [{
-          model: db.Scale,
+
+    const assessmentDefault = {
+      userId: req.params.userId,
+      rubricId: req.params.rubricId
+    }
+    return db.Assessment.findOrCreate({ where: params, defaults: assessmentDefault })
+      .spread((assessment, created) => {
+        const message = created ? "Assessment was successfully created" : "Assessment was successfully found"
+        console.log(message)
+
+        db.Rubric.findOne({
+          where: {
+            id: req.params.rubricId
+          },
           include: [{
-            model: db.Criterion,
+            model: db.Competency,
             include: [{
-              model: db.Action,
+              model: db.Scale,
+              include: [{
+                model: db.Criterion,
+                include: [{
+                  model: db.Action,
+                }],
+                order: [ [ { model: db.Action }, 'id', 'ASC' ] ]
+              }],
+              order: [ [ { model: db.Criterion }, 'id', 'ASC' ] ]
             }],
-            order: [ [ { model: db.Action }, 'id', 'ASC' ] ]
+            order: [ [ { model: db.Scale }, 'id', 'ASC' ] ]
           }],
-          order: [ [ { model: db.Criterion }, 'id', 'ASC' ] ]
-        }],
-        order: [ [ { model: db.Scale }, 'id', 'ASC' ] ]
-      }],
-      order: [ [ { model: db.Competency }, 'id', 'ASC' ] ]
-    })
-    .then((rubric) => {
-      console.log("Rubric: ", rubric.name)
-      const assessment = {
-        userId: req.params.userId,
-        rubricId: req.params.rubricId,
-        rubricJSON: rubric,
-      }
-      return db.Assessment.findOrCreate({ where: params, defaults: assessment })
-    })
-    .spread((assessment, created) => {
-      const message = created ? "Assessment was successfully created" : "Assessment was successfully found"
-      console.log(message)
-      res.send({
-        message,
-        created,
-        assessment
+          order: [ [ { model: db.Competency }, 'id', 'ASC' ] ]
+        })
+        .then((rubric) => {
+          console.log("Rubric: ", rubric.name)
+          console.log("Assessment: ", assessment.dataValues);
+          res.send({
+            message,
+            created,
+            assessment: Object.assign({}, assessment.dataValues, {rubricJSON: rubric})
+          })
+        })
       })
-    })
-    .catch((err) => {
-      console.log(err);
-      res.status(400);
-      res.json({
-        message: "Error!",
-        error: err
+      .catch((err) => {
+        console.log(err);
+        res.status(400);
+        res.json({
+          message: "Error!",
+          error: err
+        })
       })
-    })
 
     // db.Assessment.findOrCreate({ where: params, defaults: req.body })
     // .all().then((assessment, created) => {

--- a/migrations/20180204060344-create-assessment.js
+++ b/migrations/20180204060344-create-assessment.js
@@ -8,9 +8,6 @@ module.exports = {
         primaryKey: true,
         type: Sequelize.INTEGER
       },
-      rubricJSON: {
-        type: Sequelize.JSON
-      },
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE

--- a/models/assessment.js
+++ b/models/assessment.js
@@ -1,7 +1,6 @@
 'use strict';
 module.exports = (sequelize, DataTypes) => {
   var Assessment = sequelize.define('Assessment', {
-    rubricJSON: DataTypes.JSON
   }, {
     classMethods: {
       associate: function(models) {


### PR DESCRIPTION
1. cleanUp Assessment Controller for `Assessment SHOW OR INIT` route. 
2. removing the `rubricsJSON` column from the Assessment Model database. There's no need to store the `rubricsJSON` inside the AssessmentModel since we can access it through Rubrics Model, 
3. updated the Assessment Controller and Tested it at our local server through Postman

Reason for this change is  that every time we update any of the descending elements of Rubrics (Competency, Scales, Criterion), we will need to update the rubricsJSON inside the Assessment Model.


- future suggestion is to use `serializer` for our controller, so our controller does not look so messy. Potential tool we can use is `sequelize-to-json`
https://www.npmjs.com/package/sequelize-to-json

